### PR TITLE
Update requirements.txt for marhsmallow error

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -8,6 +8,7 @@ openai>=1.12.0
 google-generativeai>=0.3.2
 google-cloud-aiplatform>=1.38.0
 jsonschema>=4.19.1
+marshmallow>=3.0.0,<4.0.0
 python-dotenv>=1.0.0
 pymilvus>=1.1.0
 qdrant-client>=1.14.0


### PR DESCRIPTION
marshmallow 4.0.0 is installed by default which causes errors. This restricts the version.