### PR TITLE
pymilvius errors out at marshmallow == 4.0.0

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -9,6 +9,7 @@ google-generativeai>=0.3.2
 google-cloud-aiplatform>=1.38.0
 jsonschema>=4.19.1
 mcp>=1.0.0
+marshmallow<4.0.0
 python-dotenv>=1.0.0
 pymilvus>=1.1.0
 qdrant-client>=1.14.0


### PR DESCRIPTION
Without that, I get:

```
  File "explore/code/NLWeb/code/retrieval/milvus_client.py", line 14, in <module>
    from pymilvus import MilvusClient
  File "explore/code/NLWeb/myenv/lib/python3.13/site-packages/pymilvus/__init__.py", line 14, in <module>
    from .client.abstract import AnnSearchRequest, Hit, Hits, RRFRanker, SearchResult, WeightedRanker
  File "explore/code/NLWeb/myenv/lib/python3.13/site-packages/pymilvus/client/abstract.py", line 8, in <module>
    from pymilvus.settings import Config
  File "explore/code/NLWeb/myenv/lib/python3.13/site-packages/pymilvus/settings.py", line 4, in <module>
    import environs
  File "explore/code/NLWeb/myenv/lib/python3.13/site-packages/environs/__init__.py", line 58, in <module>
    _SUPPORTS_LOAD_DEFAULT = ma.__version_info__ >= (3, 13)
                             ^^^^^^^^^^^^^^^^^^^
```

Of course the other option is to not import deps unless they are used in `retriever.py`, but this is quicker.