### PR TITLE
Enable multple endpoints for llm provider

### DIFF
--- a/code/azure-connectivity.py
+++ b/code/azure-connectivity.py
@@ -64,11 +64,11 @@ async def check_inception_api():
     print("\nChecking Inception API connectivity...")
     
     # Check if Inception is configured
-    if "inception" not in CONFIG.llm_providers:
+    if "inception" not in CONFIG.llm_endpoints:
         print("❌ Inception provider not configured")
         return False
     
-    inception_config = CONFIG.llm_providers["inception"]
+    inception_config = CONFIG.llm_endpoints["inception"]
     api_key = inception_config.api_key
     
     if not api_key:
@@ -89,11 +89,11 @@ async def check_openai_api():
     print("\nChecking OpenAI API connectivity...")
     
     # Check if OpenAI is configured
-    if "openai" not in CONFIG.llm_providers:
+    if "openai" not in CONFIG.llm_endpoints:
         print("❌ OpenAI provider not configured")
         return False
     
-    openai_config = CONFIG.llm_providers["openai"]
+    openai_config = CONFIG.llm_endpoints["openai"]
     api_key = openai_config.api_key
     
     if not api_key:
@@ -114,11 +114,11 @@ async def check_azure_openai_api():
     print("\nChecking Azure OpenAI API connectivity...")
     
     # Check if Azure OpenAI is configured
-    if "azure_openai" not in CONFIG.llm_providers:
+    if "azure_openai" not in CONFIG.llm_endpoints:
         print("❌ Azure OpenAI provider not configured")
         return False
     
-    azure_config = CONFIG.llm_providers["azure_openai"]
+    azure_config = CONFIG.llm_endpoints["azure_openai"]
     api_key = azure_config.api_key
     endpoint = azure_config.endpoint
     api_version = azure_config.api_version or "2024-12-01-preview"
@@ -199,7 +199,7 @@ async def check_embedding_api():
 async def main():
     """Run all connectivity checks"""
     print("Running Azure connectivity checks...")
-    print(f"Using configuration from preferred LLM provider: {CONFIG.preferred_llm_provider}")
+    print(f"Using configuration from preferred LLM endpoint: {CONFIG.preferred_llm_endpoint}")
     print(f"Using configuration from preferred embedding provider: {CONFIG.preferred_embedding_provider}")
     print(f"Using configuration from preferred retrieval endpoint: {CONFIG.preferred_retrieval_endpoint}")
     

--- a/code/config/#config_llm.yaml#
+++ b/code/config/#config_llm.yaml#
@@ -1,10 +1,10 @@
-preferred_endpoint: azure_openai
+preferred_provider: azure_openai_ABBA
 
-endpoints:
+:
   inception:
     api_key_env: INCEPTION_API_KEY
     api_endpoint_env: INCEPTION_ENDPOINT
-    llm_type: inception
+    name: Inception
     models:
       high: mercury-small
       low: mercury-small
@@ -12,21 +12,18 @@ endpoints:
   openai:
     api_key_env: OPENAI_API_KEY
     api_endpoint_env: OPENAI_ENDPOINT
-    llm_type: openai
     models:
       high: gpt-4.1
       low: gpt-4.1-mini
 
   anthropic:
     api_key_env: ANTHROPIC_API_KEY
-    llm_type: anthropic
     models:
       high: claude-3-5-sonnet-20241022
       low: claude-3-haiku-20240307
 
   gemini:
     api_key_env: GCP_PROJECT
-    llm_type: gemini
     models:
       high: chat-bison@001
       low: chat-bison-lite@001
@@ -34,6 +31,14 @@ endpoints:
   azure_openai:
     api_key_env: AZURE_OPENAI_API_KEY
     api_endpoint_env: AZURE_OPENAI_ENDPOINT
+    api_version_env: "2024-12-01-preview"
+    models:
+      high: gpt-4.1
+      low: gpt-4.1-mini
+
+  azure_openai_ABBA:
+    api_key_env: AZURE_OPENAI_API_KEY_SWEDEN
+    api_endpoint_env: AZURE_OPENAI_ENDPOINT_SWEDEN
     api_version_env: "2024-12-01-preview"
     llm_type: azure_openai
     models:
@@ -44,7 +49,6 @@ endpoints:
     api_key_env: LLAMA_AZURE_API_KEY
     api_endpoint_env: LLAMA_AZURE_ENDPOINT
     api_version_env: "2024-12-01-preview"
-    llm_type: llama_azure
     models:
       high: llama-2-70b
       low: llama-2-13b
@@ -53,7 +57,6 @@ endpoints:
     api_key_env: DEEPSEEK_AZURE_API_KEY
     api_endpoint_env: DEEPSEEK_AZURE_ENDPOINT
     api_version_env: "2024-12-01-preview"
-    llm_type: deepseek_azure
     models:
       high: deepseek-coder-33b
       low: deepseek-coder-7b
@@ -63,7 +66,6 @@ endpoints:
     api_key_env: SNOWFLAKE_PAT
     api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     api_version_env: "2024-12-01"
-    llm_type: snowflake
     models:
       high: claude-3-5-sonnet
       low: llama3.1-8b

--- a/code/config/config.py
+++ b/code/config/config.py
@@ -21,6 +21,7 @@ class ModelConfig:
 
 @dataclass
 class LLMProviderConfig:
+    llm_type: str
     api_key: Optional[str] = None
     models: Optional[ModelConfig] = None
     endpoint: Optional[str] = None
@@ -150,10 +151,10 @@ class AppConfig:
         with open(full_path, "r") as f:
             data = yaml.safe_load(f)
 
-            self.preferred_llm_provider: str = data["preferred_provider"]
-            self.llm_providers: Dict[str, LLMProviderConfig] = {}
+            self.preferred_llm_endpoint: str = data["preferred_endpoint"]
+            self.llm_endpoints: Dict[str, LLMProviderConfig] = {}
 
-            for name, cfg in data.get("providers", {}).items():
+            for name, cfg in data.get("endpoints", {}).items():
                 m = cfg.get("models", {})
                 models = ModelConfig(
                     high=self._get_config_value(m.get("high")),
@@ -164,8 +165,10 @@ class AppConfig:
                 api_key = self._get_config_value(cfg.get("api_key_env"))
                 api_endpoint = self._get_config_value(cfg.get("api_endpoint_env"))
                 api_version = self._get_config_value(cfg.get("api_version_env"))
+                llm_type = self._get_config_value(cfg.get("llm_type"))
                 # Create the LLM provider config - no longer include embedding model
-                self.llm_providers[name] = LLMProviderConfig(
+                self.llm_endpoints[name] = LLMProviderConfig(
+                    llm_type=llm_type,
                     api_key=api_key,
                     models=models,
                     endpoint=api_endpoint,
@@ -444,14 +447,14 @@ class AppConfig:
             
     def get_llm_provider(self, provider_name: Optional[str] = None) -> Optional[LLMProviderConfig]:
         """Get the specified LLM provider config or the preferred one if not specified."""
-        if not hasattr(self, 'llm_providers'):
+        if not hasattr(self, 'llm_endpoints'):
             return None
             
-        if provider_name and provider_name in self.llm_providers:
-            return self.llm_providers[provider_name]
+        if provider_name and provider_name in self.llm_endpoints:
+            return self.llm_endpoints[provider_name]
             
-        if hasattr(self, 'preferred_llm_provider') and self.preferred_llm_provider in self.llm_providers:
-            return self.llm_providers[self.preferred_llm_provider]
+        if hasattr(self, 'preferred_llm_endpoint') and self.preferred_llm_endpoint in self.llm_endpoints:
+            return self.llm_endpoints[self.preferred_llm_endpoint]
             
         return None
 

--- a/code/config/config_retrieval.yaml
+++ b/code/config/config_retrieval.yaml
@@ -6,7 +6,6 @@ endpoints:
     api_endpoint_env: AZURE_VECTOR_SEARCH_ENDPOINT
     index_name: embeddings1536
     db_type: azure_ai_search
-    name: NLWeb_Crawl
 
   # Milvus is still under development and not yet supported. 
   # milvus_1:

--- a/code/llm/anthropic.py
+++ b/code/llm/anthropic.py
@@ -39,7 +39,7 @@ class AnthropicProvider(LLMProvider):
     def get_api_key(cls) -> str:
         """Retrieve the Anthropic API key from the environment or raise an error."""
         # Get the API key from the preferred provider config
-        provider_config = CONFIG.llm_providers["anthropic"]
+        provider_config = CONFIG.llm_endpoints["anthropic"]
         if provider_config and provider_config.api_key:
             api_key = provider_config.api_key
             if api_key:
@@ -102,7 +102,7 @@ class AnthropicProvider(LLMProvider):
         """
         # If model not provided, get it from config
         if model is None:
-            provider_config = CONFIG.llm_providers["anthropic"]
+            provider_config = CONFIG.llm_endpoints["anthropic"]
             # Use the 'high' model for completions by default
             model = provider_config.models.high
         

--- a/code/llm/azure_deepseek.py
+++ b/code/llm/azure_deepseek.py
@@ -34,7 +34,7 @@ class DeepSeekAzureProvider(LLMProvider):
     def get_azure_endpoint(cls) -> str:
         """Get DeepSeek Azure endpoint from config"""
         logger.debug("Retrieving DeepSeek Azure endpoint from config")
-        provider_config = CONFIG.providers.get("deepseek_azure")
+        provider_config = CONFIG.llm_endpoints.get("deepseek_azure")
         if provider_config and provider_config.endpoint:
             endpoint = provider_config.endpoint
             if endpoint:
@@ -48,7 +48,7 @@ class DeepSeekAzureProvider(LLMProvider):
     def get_api_key(cls) -> str:
         """Get DeepSeek Azure API key from config"""
         logger.debug("Retrieving DeepSeek Azure API key from config")
-        provider_config = CONFIG.providers.get("deepseek_azure")
+        provider_config = CONFIG.llm_endpoints.get("deepseek_azure")
         if provider_config and provider_config.api_key:
             api_key = provider_config.api_key
             if api_key:
@@ -62,7 +62,7 @@ class DeepSeekAzureProvider(LLMProvider):
     def get_api_version(cls) -> str:
         """Get DeepSeek Azure API version from config"""
         logger.debug("Retrieving DeepSeek Azure API version from config")
-        provider_config = CONFIG.providers.get("deepseek_azure")
+        provider_config = CONFIG.llm_endpoints.get("deepseek_azure")
         if provider_config and provider_config.api_version:
             logger.debug(f"DeepSeek Azure API version: {provider_config.api_version}")
             return provider_config.api_version
@@ -135,7 +135,7 @@ class DeepSeekAzureProvider(LLMProvider):
         """Get completion from DeepSeek on Azure"""
         if model is None:
             # Get model from config if not provided
-            provider_config = CONFIG.providers.get("deepseek_azure")
+            provider_config = CONFIG.llm_endpoints.get("deepseek_azure")
             model = provider_config.models.high if provider_config else "deepseek-coder-33b"
         
         logger.info(f"Getting DeepSeek completion with model: {model}")
@@ -172,7 +172,7 @@ Only output the JSON object itself, with no markdown formatting, no explanations
             logger.error(f"DeepSeek completion timed out after {timeout}s")
             raise
         except Exception as e:
-            logger.exception("Error during DeepSeek completion")
+            logger.error(f"DeepSeek completion failed: {type(e).__name__}: {str(e)}")
             raise
 
 

--- a/code/llm/azure_llama.py
+++ b/code/llm/azure_llama.py
@@ -34,7 +34,7 @@ class LlamaAzureProvider(LLMProvider):
     def get_azure_endpoint(cls) -> str:
         """Get Llama Azure endpoint from config"""
         logger.debug("Retrieving Llama Azure endpoint from config")
-        provider_config = CONFIG.providers.get("llama_azure")
+        provider_config = CONFIG.llm_endpoints.get("llama_azure")
         if provider_config and provider_config.endpoint:
             endpoint = provider_config.endpoint
             if endpoint:
@@ -48,7 +48,7 @@ class LlamaAzureProvider(LLMProvider):
     def get_api_key(cls) -> str:
         """Get Llama Azure API key from config"""
         logger.debug("Retrieving Llama Azure API key from config")
-        provider_config = CONFIG.providers.get("llama_azure")
+        provider_config = CONFIG.llm_endpoints.get("llama_azure")
         if provider_config and provider_config.api_key:
             api_key = provider_config.api_key
             if api_key:
@@ -62,7 +62,7 @@ class LlamaAzureProvider(LLMProvider):
     def get_api_version(cls) -> str:
         """Get Llama Azure API version from config"""
         logger.debug("Retrieving Llama Azure API version from config")
-        provider_config = CONFIG.providers.get("llama_azure")
+        provider_config = CONFIG.llm_endpoints.get("llama_azure")
         if provider_config and provider_config.api_version:
             logger.debug(f"Llama Azure API version: {provider_config.api_version}")
             return provider_config.api_version
@@ -135,7 +135,7 @@ class LlamaAzureProvider(LLMProvider):
         """Get completion from Llama on Azure"""
         if model is None:
             # Get model from config if not provided
-            provider_config = CONFIG.providers.get("llama_azure")
+            provider_config = CONFIG.llm_endpoints.get("llama_azure")
             model = provider_config.models.high if provider_config else "llama-2-70b"
         
         logger.info(f"Getting Llama completion with model: {model}")
@@ -172,7 +172,7 @@ Only output the JSON object, no additional text or explanation."""
             logger.error(f"Llama completion timed out after {timeout}s")
             raise
         except Exception as e:
-            logger.exception("Error during Llama completion")
+            logger.error(f"Llama completion failed: {type(e).__name__}: {str(e)}")
             raise
 
 

--- a/code/llm/azure_oai.py
+++ b/code/llm/azure_oai.py
@@ -31,7 +31,7 @@ class AzureOpenAIProvider(LLMProvider):
     @classmethod
     def get_azure_endpoint(cls) -> str:
         """Get the Azure OpenAI endpoint from configuration."""
-        provider_config = CONFIG.llm_providers.get("azure_openai")
+        provider_config = CONFIG.llm_endpoints.get("azure_openai")
         if provider_config and provider_config.endpoint:
             endpoint = provider_config.endpoint
             if endpoint:
@@ -42,7 +42,7 @@ class AzureOpenAIProvider(LLMProvider):
     @classmethod
     def get_api_key(cls) -> str:
         """Get the Azure OpenAI API key from configuration."""
-        provider_config = CONFIG.llm_providers.get("azure_openai")
+        provider_config = CONFIG.llm_endpoints.get("azure_openai")
         if provider_config and provider_config.api_key:
             api_key = provider_config.api_key
             if api_key:
@@ -53,7 +53,7 @@ class AzureOpenAIProvider(LLMProvider):
     @classmethod
     def get_api_version(cls) -> str:
         """Get the Azure OpenAI API version from configuration."""
-        provider_config = CONFIG.llm_providers.get("azure_openai")
+        provider_config = CONFIG.llm_endpoints.get("azure_openai")
         if provider_config and provider_config.api_version:
             api_version = provider_config.api_version
             return api_version
@@ -64,7 +64,7 @@ class AzureOpenAIProvider(LLMProvider):
     @classmethod
     def get_model_from_config(cls, high_tier=False) -> str:
         """Get the appropriate model from configuration based on tier."""
-        provider_config = CONFIG.llm_providers.get("azure_openai")
+        provider_config = CONFIG.llm_endpoints.get("azure_openai")
         if provider_config and provider_config.models:
             model_name = provider_config.models.high if high_tier else provider_config.models.low
             if model_name:
@@ -223,7 +223,7 @@ class AzureOpenAIProvider(LLMProvider):
             logger.error(f"Azure OpenAI request timed out after {timeout} seconds")
             raise
         except Exception as e:
-            logger.exception(f"Error in Azure OpenAI completion: {str(e)}")
+            logger.error(f"Azure OpenAI completion failed: {type(e).__name__}: {str(e)}")
             raise
 
 

--- a/code/llm/gemini.py
+++ b/code/llm/gemini.py
@@ -40,7 +40,7 @@ class GeminiProvider(LLMProvider):
     def get_gcp_project(cls) -> str:
         """Retrieve the GCP project ID from the environment or raise an error."""
         # Get the project ID from the preferred provider config
-        provider_config = CONFIG.llm_providers["gemini"]
+        provider_config = CONFIG.llm_endpoints["gemini"]
         
         # For Gemini, we need the GCP project ID, which might be stored in API_KEY_ENV or a specific field
         # First check if there's a specific project env var in the config
@@ -59,8 +59,8 @@ class GeminiProvider(LLMProvider):
     @classmethod
     def get_api_key(cls) -> Optional[str]:
         """Retrieve the API key if needed for Gemini API."""
-        preferred_provider = CONFIG.preferred_llm_provider
-        provider_config = CONFIG.llm_providers[preferred_provider]
+        preferred_endpoint = CONFIG.preferred_llm_endpoint
+        provider_config = CONFIG.llm_endpoints[preferred_endpoint]
         api_key_env_var = provider_config.api_key_env
         
         if api_key_env_var:
@@ -118,7 +118,7 @@ class GeminiProvider(LLMProvider):
         """Async chat completion using Vertex AI (Gemini)."""
         # If model not provided, get it from config
         if model is None:
-            provider_config = CONFIG.llm_providers["gemini"]
+            provider_config = CONFIG.llm_endpoints["gemini"]
             # Use the 'high' model for completions by default
             model = provider_config.models.high
         

--- a/code/llm/llm.py
+++ b/code/llm/llm.py
@@ -28,8 +28,8 @@ from llm.snowflake import provider as snowflake_provider
 from utils.logging_config_helper import get_configured_logger, LogLevel
 logger = get_configured_logger("llm_wrapper")
 
-# Provider mapping
-_providers = {
+# LLM type to provider mapping
+_llm_type_providers = {
     "openai": openai_provider,
     "anthropic": anthropic_provider,
     "gemini": gemini_provider,
@@ -48,12 +48,12 @@ async def ask_llm(
     timeout: int = 8
 ) -> Dict[str, Any]:
     """
-    Route an LLM request to the specified provider.
+    Route an LLM request to the specified endpoint, with dispatch based on llm_type.
     
     Args:
         prompt: The text prompt to send to the LLM
         schema: JSON schema that the response should conform to
-        provider: The LLM provider to use (if None, use preferred provider from config)
+        provider: The LLM endpoint to use (if None, use preferred endpoint from config)
         level: The model tier to use ('low' or 'high')
         timeout: Request timeout in seconds
         
@@ -61,15 +61,15 @@ async def ask_llm(
         Parsed JSON response from the LLM
         
     Raises:
-        ValueError: If the provider is unknown or response cannot be parsed
+        ValueError: If the endpoint is unknown or response cannot be parsed
         TimeoutError: If the request times out
     """
-    provider_name = provider or CONFIG.preferred_llm_provider
+    provider_name = provider or CONFIG.preferred_llm_endpoint
     logger.debug(f"Initiating LLM request with provider: {provider_name}, level: {level}")
     logger.debug(f"Prompt preview: {prompt[:100]}...")
     logger.debug(f"Schema: {schema}")
     
-    if provider_name not in CONFIG.llm_providers:
+    if provider_name not in CONFIG.llm_endpoints:
         error_msg = f"Unknown provider '{provider_name}'"
         logger.error(error_msg)
         print(f"Unknown provider '{provider_name}'")
@@ -82,22 +82,29 @@ async def ask_llm(
         logger.error(error_msg)
         raise ValueError(error_msg)
 
+    # Get llm_type for dispatch
+    llm_type = provider_config.llm_type
+    logger.debug(f"Using LLM type: {llm_type}")
+
     model_id = getattr(provider_config.models, level)
     logger.debug(f"Using model: {model_id}")
+    
+    # Initialize variables for exception handling
+    llm_type_for_error = llm_type
 
     try:
 
-        # Get the provider instance
-        if provider_name not in _providers:
-            error_msg = f"No implementation for provider '{provider_name}'"
+        # Get the provider instance based on llm_type
+        if llm_type not in _llm_type_providers:
+            error_msg = f"No implementation for LLM type '{llm_type}'"
             logger.error(error_msg)
             raise ValueError(error_msg)
             
-        provider_instance = _providers[provider_name]
+        provider_instance = _llm_type_providers[llm_type]
         
         # Simply call the provider's get_completion method without locking
         # Each provider should handle thread-safety internally
-        logger.debug(f"Calling {provider_name} completion")
+        logger.debug(f"Calling {llm_type} provider completion for endpoint {provider_name}")
         result = await asyncio.wait_for(
             provider_instance.get_completion(prompt, schema, model=model_id),
             timeout=timeout
@@ -109,12 +116,15 @@ async def ask_llm(
         logger.error(f"LLM call timed out after {timeout}s with provider {provider_name}")
         raise
     except Exception as e:
-        logger.exception(f"Error during LLM call with provider {provider_name}")
+        error_msg = f"LLM call failed: {type(e).__name__}: {str(e)}"
+        logger.error(f"Error with provider {provider_name}: {error_msg}")
+        print(f"LLM Error ({provider_name}): {type(e).__name__}: {str(e)}")
         logger.log_with_context(
             LogLevel.ERROR,
             "LLM call failed",
             {
-                "provider": provider_name,
+                "endpoint": provider_name,
+                "llm_type": llm_type_for_error,
                 "model": model_id,
                 "level": level,
                 "error_type": type(e).__name__,

--- a/code/llm/openai.py
+++ b/code/llm/openai.py
@@ -48,7 +48,7 @@ class OpenAIProvider(LLMProvider):
         Retrieve the OpenAI API key from environment or raise an error.
         """
         # Get the API key from the preferred provider config
-        provider_config = CONFIG.llm_providers["openai"]
+        provider_config = CONFIG.llm_endpoints["openai"]
         api_key = provider_config.api_key
         return api_key
 
@@ -106,7 +106,7 @@ class OpenAIProvider(LLMProvider):
         """
         # If model not provided, get it from config
         if model is None:
-            provider_config = CONFIG.llm_providers["openai"]
+            provider_config = CONFIG.llm_endpoints["openai"]
             # Use the 'high' model for completions by default
             model = provider_config.models.high
         

--- a/code/llm/snowflake.py
+++ b/code/llm/snowflake.py
@@ -119,7 +119,7 @@ async def cortex_complete(
     return SnowflakeProvider.clean_response(response.get("choices")[0].get("message").get("content").strip())
 
 async def post(api: str, request: dict, timeout: float) -> dict:
-    cfg = CONFIG.llm_providers.get("snowflake")
+    cfg = CONFIG.llm_endpoints.get("snowflake")
     async with httpx.AsyncClient() as client:
         response =  await client.post(
             snowflake.get_account_url(cfg) + api,

--- a/code/prompts/prompt_runner.py
+++ b/code/prompts/prompt_runner.py
@@ -70,6 +70,4 @@ class PromptRunner:
             logger.error(f"Error in run_prompt for '{prompt_name}': {type(e).__name__}: {str(e)}")
             logger.debug("Full traceback:", exc_info=True)
             print(f"ERROR in run_prompt: {type(e).__name__}: {str(e)}")
-            import traceback
-            traceback.print_exc()
             return None

--- a/code/tools/trim_schema_json.py
+++ b/code/tools/trim_schema_json.py
@@ -21,7 +21,8 @@ def should_skip_item(site, item):
             if type_value in skip_types:
                 return True
     elif "@type" not in item:
-        return True
+        print(f"Warning: Item without @type field found for site {site}, keeping item: {str(item)[:100]}...")
+        return False
     return False
 
 # trim the markup without loosing too much of the information that the LLM can use


### PR DESCRIPTION
Have llm config be along the lines of retrieval config, which allows for a single provider (like azure oai) to have multiple endpoints