### PR TITLE
docs: code fenced and reflowed text in the site_types.xml example

### DIFF
--- a/docs/nlweb-prompts.md
+++ b/docs/nlweb-prompts.md
@@ -3,26 +3,26 @@
 During the course of processing a single query from a user, NLWeb makes a number of LLM calls for many different kinds of tasks. These include:
 
 - 'Pre' steps, e.g.,
-  - Analyzing whether the query is relevant to the site
-  - Constructing a decontextualized query from query history
-  - Identifying whether the query mentions something that should be committed to memory
+    - Analyzing whether the query is relevant to the site
+    - Constructing a decontextualized query from query history
+    - Identifying whether the query mentions something that should be committed to memory
 - Ranking
 - 'Post'. Post steps are optional
-  - Create summary of results
-  - Try to answer the user's question using the top ranked results (this is closer to traditional RAG)
+    - Create summary of results
+    - Try to answer the user's question using the top ranked results (this is closer to traditional RAG)
 
-The prompts used for these calls are in the file site_types.xml. The behaviour of the system can be modified by changing these prompts.
+The prompts used for these calls are in the file `site_types.xml`. The behaviour of the system can be modified by changing these prompts.
 
 Given below is a sample prompt:
 
+```xml
 <Thing>
    <Prompt ref="DetectMemoryRequestPrompt">
       <promptString>
         Analyze the following statement from the user.
         Is the user asking you to remember, that may be relevant to not just this query, but also future queries?
         If so, what is the user asking us to remember?
-        The user should be explicitly asking you to remember something for future queries,
-        not just expressing a requirement for the current query.
+        The user should be explicitly asking you to remember something for future queries, not just expressing a requirement for the current query.
         The user's query is: {request.rawQuery}.
       </promptString>
       <returnStruc>
@@ -37,34 +37,14 @@ Given below is a sample prompt:
 
 </Thing>
 
-Each <tag>Prompt</tag> is identified by a 'ref' attribute, which is used
-by the code calling the LLM to construct the tag. The <tag>promptString</tag>
-follows a templated structure. Each string contains placeholders / variables
-(like {request.query}, {site.itemType}, etc.) that get dynamically populated
-during execution. The prompts typically begin by establishing context about
-the user's query and the site being searched, followed by specific instructions
-for analyzing or transforming the query or ranking the candidate item
-in the context of the query. The LLM calls always used structured output
-and the desired structure of the output is in the <tag>returnStruc</tag>
-The list of allowed placeholders is given at the end of this document.
+Each <tag>Prompt</tag> is identified by a 'ref' attribute, which is used by the code calling the LLM to construct the tag. The <tag>promptString</tag> follows a templated structure. Each string contains placeholders / variables (like {request.query}, {site.itemType}, etc.) that get dynamically populated during execution. The prompts typically begin by establishing context about the user's query and the site being searched, followed by specific instructions for analyzing or transforming the query or ranking the candidate item in the context of the query. The LLM calls always used structured output and the desired structure of the output is in the <tag>returnStruc</tag> The list of allowed placeholders is given at the end of this document.
 
-The above prompt is very generic and meant to be used for all types of
-items. However, most sites deal with a very limited number of types of items
-and more specific (and hence better performing) prompts can be designed
-for these. For example, if we know that the user is looking for a recipe,
-we can use the following more specific prompt.
+The above prompt is very generic and meant to be used for all types of items. However, most sites deal with a very limited number of types of items and more specific (and hence better performing) prompts can be designed for these. For example, if we know that the user is looking for a recipe, we can use the following more specific prompt.
 
   <Recipe>
     <Prompt ref="DetectMemoryRequestPrompt">
       <promptString>
-        Analyze the following statement from the user.
-        Is the user asking you to remember a dietary constraint, that may be relevant
-        to not just this query, but also future queries? For example, the user may say
-        that they are vegetarian or observe kosher or halal or specify an allergy.
-        If so, what is the user asking us to remember?
-        The user should be explicitly asking you to remember something for future queries,
-        not just expressing a requirement for the current query.
-        The user's query is: {request.rawQuery}.
+        Analyze the following statement from the user. Is the user asking you to remember a dietary constraint, that may be relevant to not just this query, but also future queries? For example, the user may say that they are vegetarian or observe kosher or halal or specify an allergy. If so, what is the user asking us to remember? The user should be explicitly asking you to remember something for future queries, not just expressing a requirement for the current query. The user's query is: {request.rawQuery}.
       </promptString>
       <returnStruc>
         {
@@ -75,21 +55,17 @@ we can use the following more specific prompt.
     </Prompt>
   </Recipe>
 
-In the schema.org hierarchy, <tag>Recipe</tag> is under <tag>Thing</tag> in the class
-hierarchy and hence when it is determined that the user is looking for a <tag>Recipe</tag>
-this prompt will be used.
+In the schema.org hierarchy, <tag>Recipe</tag> is under <tag>Thing</tag> in the class hierarchy and hence when it is determined that the user is looking for a <tag>Recipe</tag> this prompt will be used.
 
-Prompts can also be used to change the ranking and description associated with
-each item. For example, the default ranking prompt is:
+Prompts can also be used to change the ranking and description associated with each item. For example, the default ranking prompt is:
 
    <Prompt ref="RankingPrompt">
       <promptString>
-        Assign a score between 0 and 100 to the following item
-        based on how relevant it is to the user's question. Use your knowledge from other sources, about the item, to make a judgement.
-        If the score is above 50, provide a short description of the item highlighting the relevance to the user's question, without mentioning the user's question.
+        Assign a score between 0 and 100 to the following item based on how relevant it is to the user's question. Use your knowledge from other sources, about the item, to make a judgement. If the score is above 50, provide a short description of the item highlighting the relevance to the user's question, without mentioning the user's question.
+
         Provide an explanation of the relevance of the item to the user's question, without mentioning the user's question or the score or explicitly mentioning the term relevance.
-        If the score is below 75, in the description, include the reason why it is still relevant.
-        The user's question is: \"{request.query}\". The item's description in schema.org format is \"{item.description}\".
+
+        If the score is below 75, in the description, include the reason why it is still relevant. The user's question is: \"{request.query}\". The item's description in schema.org format is \"{item.description}\".
       </promptString>
       <returnStruc>
         {
@@ -99,15 +75,11 @@ each item. For example, the default ranking prompt is:
       </returnStruc>
    </Prompt>
 
-A site which has star ratings for items (and where the json for each item includes the star rating) might want to
-incorporate that rating into the ranking. One way of doing this would be to use a <tag>promptString</tag> that
-asks the LLM to factor this in. E.g.,
+A site which has star ratings for items (and where the json for each item includes the star rating) might want to incorporate that rating into the ranking. One way of doing this would be to use a <tag>promptString</tag> that asks the LLM to factor this in. E.g.,
 
    <Prompt ref="RankingPrompt">
       <promptString>
-        Assign a score between 0 and 100 to the following item
-        based on how relevant it is to the user's question. Incorporate the aggregateRating for the item into your
- score. Items with higher ratings should be given a higher score.
+        Assign a score between 0 and 100 to the following item based on how relevant it is to the user's question. Incorporate the aggregateRating for the item into your score. Items with higher ratings should be given a higher score.
  ...
         The user's question is: \"{request.query}\". The item's description in schema.org format is \"{item.description}\".
       </promptString>
@@ -124,10 +96,7 @@ Similarly, descriptions can also be changed. Eg.
  <Recipe>
    <Prompt ref="RankingPrompt">
       <promptString>
-        Assign a score between 0 and 100 to the following item
-        based on how relevant it is to the user's question. Include a short description of the item, focussing on the
- relevance of the teim to the user's query. Also, include the salient aspects of the nutritional value of
- this recipe.
+        Assign a score between 0 and 100 to the following item based on how relevant it is to the user's question. Include a short description of the item, focussing on the relevance of the item to the user's query. Also, include the salient aspects of the nutritional value of this recipe.
         The user's question is: \"{request.query}\". The item's description in schema.org format is \"{item.description}\".
       </promptString>
       <returnStruc>
@@ -138,6 +107,7 @@ Similarly, descriptions can also be changed. Eg.
       </returnStruc>
    </Prompt>
  </Recipe>
+ ```
 
 ## Variables
 


### PR DESCRIPTION
This pull request improves the documentation in `docs/nlweb-prompts.md` by reformatting and enhancing the readability of examples and explanations related to prompt structures. The changes include code formatting for XML examples, consolidating text for clarity, and fixing minor grammatical issues.

### Documentation Enhancements:

* Added code formatting (`<code>` blocks) for XML examples to improve readability and clarity in the documentation. [[1]](diffhunk://#diff-e03d5365f5d1b078b978d375779d5cea0108b7a8182845a04698f31af59726c2L14-R25) [[2]](diffhunk://#diff-e03d5365f5d1b078b978d375779d5cea0108b7a8182845a04698f31af59726c2R110)

* Consolidated multiline explanations into single-line formats where appropriate, making the text more concise and easier to follow. Examples include descriptions of prompt attributes, ranking logic, and placeholder usage. [[1]](diffhunk://#diff-e03d5365f5d1b078b978d375779d5cea0108b7a8182845a04698f31af59726c2L40-R47) [[2]](diffhunk://#diff-e03d5365f5d1b078b978d375779d5cea0108b7a8182845a04698f31af59726c2L78-R68) [[3]](diffhunk://#diff-e03d5365f5d1b078b978d375779d5cea0108b7a8182845a04698f31af59726c2L102-R82)

* Corrected minor grammatical issues and inconsistencies, such as fixing redundant line breaks and improving sentence flow in sections describing prompt usage and customization.