### PR TITLE
Add Sentence Transformers for embeddings

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -33,6 +33,7 @@ code/
 |   ├── embedding.py              #
 |   ├── gemini_embedding.py       #
 |   ├── openai_embedding.py       #
+|   ├── sentence_transformer_embedding.py    # 
 |   ├── snowflake_embedding.py    #
 ├── llm/
 |   ├── anthropic.py              #

--- a/code/config/config_embedding.yaml
+++ b/code/config/config_embedding.yaml
@@ -21,3 +21,6 @@ providers:
     api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     api_version_env: "2024-10-01"
     model: snowflake-arctic-embed-m-v1.5
+
+  sentence-transformers:
+    model: all-MiniLM-L6-v2   

--- a/code/embedding/embedding.py
+++ b/code/embedding/embedding.py
@@ -22,7 +22,9 @@ _provider_locks = {
     "openai": threading.Lock(),
     "gemini": threading.Lock(),
     "azure_openai": threading.Lock(),
-    "snowflake": threading.Lock()
+    "snowflake": threading.Lock(),
+    "snowflake": threading.Lock(),
+    "sentence-transformers": threading.Lock()
 }
 
 async def get_embedding(
@@ -113,6 +115,17 @@ async def get_embedding(
                 timeout=timeout
             )
             logger.debug(f"Snowflake Cortex embeddings received, dimension: {len(result)}")
+            return result
+
+        if provider == "sentence-transformers":
+            logger.debug("Getting SentenceTransformer embeddings")
+            # Import here to avoid potential circular imports
+            from embedding.sentence_transformer_embedding import get_sentence_transformer_embedding
+            result = await asyncio.wait_for(
+                get_sentence_transformer_embedding(text, model=model_id),
+                timeout=timeout
+            )
+            logger.debug(f"SentenceTransformer embeddings received, dimension: {len(result)}")
             return result
 
         error_msg = f"No embedding implementation for provider '{provider}'"

--- a/code/embedding/sentence_transformer_embedding.py
+++ b/code/embedding/sentence_transformer_embedding.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+SentenceTransformer-based local embedding implementation.
+
+WARNING: This code is under development and may undergo changes in future releases.
+Backwards compatibility is not guaranteed at this time.
+"""
+
+import os
+import threading
+from typing import List, Optional
+
+from sentence_transformers import SentenceTransformer
+
+from config.config import CONFIG
+from utils.logging_config_helper import get_configured_logger, LogLevel
+
+logger = get_configured_logger("sentence_transformer_embedding")
+
+# Thread-safe singleton initialization
+_model_lock = threading.Lock()
+embedding_model = None
+
+def get_model_name() -> str:
+    """
+    Retrieve the embedding model name from configuration or default.
+    """
+    provider_config = CONFIG.get_embedding_provider("sentence_transformer")
+    if provider_config and provider_config.model:
+        return provider_config.model
+    return "all-MiniLM-L6-v2"  # Default lightweight model
+
+def get_embedding_model() -> SentenceTransformer:
+    """
+    Load and return a singleton SentenceTransformer model.
+    """
+    global embedding_model
+    with _model_lock:
+        if embedding_model is None:
+            model_name = get_model_name()
+            try:
+                embedding_model = SentenceTransformer(model_name)
+                logger.info(f"Loaded SentenceTransformer model: {model_name}")
+            except Exception as e:
+                logger.exception(f"Failed to load SentenceTransformer model: {model_name}")
+                raise
+    return embedding_model
+
+async def get_sentence_transformer_embedding(
+    text: str,
+    model: Optional[str] = None,
+    timeout: float = 30.0
+) -> List[float]:
+    """
+    Generate a single embedding using SentenceTransformer.
+
+    Args:
+        text: The input text to embed.
+        model: Optional model name to override config.
+        timeout: Unused, for compatibility.
+
+    Returns:
+        Embedding vector as list of floats.
+    """
+    try:
+        model_instance = get_embedding_model()
+        embedding = model_instance.encode(text.replace("\n", " "), convert_to_numpy=True).tolist()
+        logger.debug(f"Generated embedding (dim={len(embedding)})")
+        return embedding
+    except Exception as e:
+        logger.exception("Error generating SentenceTransformer embedding")
+        raise
+
+async def get_sentence_transformer_batch_embeddings(
+    texts: List[str],
+    model: Optional[str] = None,
+    timeout: float = 60.0
+) -> List[List[float]]:
+    """
+    Generate batch embeddings using SentenceTransformer.
+
+    Args:
+        texts: List of input texts.
+        model: Optional model name to override config.
+        timeout: Unused, for compatibility.
+
+    Returns:
+        List of embedding vectors.
+    """
+    try:
+        model_instance = get_embedding_model()
+        cleaned_texts = [t.replace("\n", " ") for t in texts]
+        embeddings = model_instance.encode(cleaned_texts, convert_to_numpy=True).tolist()
+        logger.debug(f"Generated {len(embeddings)} embeddings (dim={len(embeddings[0])})")
+        return embeddings
+    except Exception as e:
+        logger.exception("Error generating batch embeddings with SentenceTransformer")
+        raise

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -19,4 +19,4 @@ aiohttp>=3.9.1
 pyyaml>=6.0.1
 feedparser>=6.0.1
 httpx>=0.28.1
-
+sentence-transformers>=4.1.0

--- a/docs/SentenceTransformers.md
+++ b/docs/SentenceTransformers.md
@@ -1,0 +1,10 @@
+# Sentence Transformers Embedding Framework
+
+The `sentence_transformers` framework provides a unified interface for working with embedding and reranker models. It is used by the `db_load` tool to compute vector embeddings when inserting documents into the database.
+
+We use the `all-MiniLM-L6-v2` model as the default embedding model, which offers a strong balance between speed and embedding quality for general-purpose use. The resulting vectors are 384-dimensional.
+
+A wide range of models is supported through the framework. See the full list at [sentence-transformers on Hugging Face](https://huggingface.co/sentence-transformers).
+
+**Note**: Embedding vector size is defined by the model. If you change models or providers and encounter a vector size mismatch error, you may need to delete your existing embeddings database and regenerate it using the `db_load` tool.
+


### PR DESCRIPTION
Hi there, I'm Ivo and I am loving the project,

This PR introduces support for Sentence Transformers (documentation [here](https://huggingface.co/sentence-transformers)) as an embedding option. I've followed the documentation [here](https://github.com/microsoft/NLWeb/tree/main/docs).

To test, set the code/config/config_embedding.yaml to be ```preferred_provider: sentence-transformers``` and redo the db_load `python -m tools.db_load https://feeds.libsyn.com/121695/rss Behind-the-Tech`.  

I reset the code/config/config_embedding.yaml to be ```preferred_provider: azure_openai``` as per the repo

Looking forward to your feedback!