### PR TITLE
Check for 'origin' header

### DIFF
--- a/code/webserver/WebServer.py
+++ b/code/webserver/WebServer.py
@@ -128,7 +128,7 @@ async def handle_client(reader, writer, fulfill_request):
                 writer.write(status_line.encode('utf-8'))
                 
                 # Add CORS headers if enabled
-                if CONFIG.server.enable_cors and 'Origin' in headers:
+                if CONFIG.server.enable_cors and 'origin' in headers:
                     response_headers['Access-Control-Allow-Origin'] = '*'
                     response_headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
                     response_headers['Access-Control-Allow-Headers'] = 'Content-Type'


### PR DESCRIPTION
Check that 'origin' header exists instead of 'Origin'.

When you parse headers you lowercase all the header keys. So there will never be a header with the key 'Origin'. It will be 'origin', So the CORS configuration will never work. This PR should fix that.

Fixes #178 