### PR TITLE
Passing timeout parameter to LLM

### DIFF
--- a/code/llm/llm.py
+++ b/code/llm/llm.py
@@ -219,8 +219,10 @@ async def ask_llm(
         # Simply call the provider's get_completion method without locking
         # Each provider should handle thread-safety internally
         logger.debug(f"Calling {llm_type} provider completion for endpoint {provider_name}")
-        result = await asyncio.wait_for(
-            provider_instance.get_completion(prompt, schema, model=model_id),
+        result = await provider_instance.get_completion(
+            prompt,
+            schema,
+            model=model_id,
             timeout=timeout
         )
         logger.debug(f"{provider_name} response received, size: {len(str(result))} chars")


### PR DESCRIPTION
There is a bug as w don't pass the timeout parameter to LLM when we use ask_llm() function and that's why hard-code its limit to 8 sec. This implementation addresses the bug, plus the provider can handle asynchronous run of get_completion().