### PR TITLE
Fix Unvalidated dynamic method call typeRenderers

### DIFF
--- a/static/json-renderer.js
+++ b/static/json-renderer.js
@@ -15,6 +15,7 @@ export class JsonRenderer {
     
     // Registry for type-specific renderers
     this.typeRenderers = {};
+    this.validTypeRenderers = new Set(); // Whitelist of valid method names
   }
   
   /**
@@ -24,7 +25,12 @@ export class JsonRenderer {
    * @param {Function} renderer - The renderer function
    */
   registerTypeRenderer(type, renderer) {
-    this.typeRenderers[type] = renderer;
+    if (typeof type === 'string' && typeof renderer === 'function') {
+      this.typeRenderers[type] = renderer;
+      this.validTypeRenderers.add(type); // Add to whitelist
+    } else {
+      throw new Error('Invalid type or renderer');
+    }
   }
   
   /**
@@ -64,8 +70,9 @@ export class JsonRenderer {
     }
     if (item.schema_object && item.schema_object['@type']) {
       const type = item.schema_object['@type'];
-      if (Object.prototype.hasOwnProperty.call(this.typeRenderers, type) && 
-             typeof this.typeRenderers[type] === 'function') {
+      if (this.validTypeRenderers.has(type) && 
+          Object.prototype.hasOwnProperty.call(this.typeRenderers, type) && 
+          typeof this.typeRenderers[type] === 'function') {
         return this.typeRenderers[type](item, this);
       } 
     }


### PR DESCRIPTION
https://github.com/microsoft/NLWeb/blob/59350b0a4a9c71fe6a8457040541d825f1161342/static/json-renderer.js#L27-L27
https://github.com/microsoft/NLWeb/blob/59350b0a4a9c71fe6a8457040541d825f1161342/static/json-renderer.js#L67-L69

Fix the issue ensure that the dynamic method lookup is safe and restricted to a predefined set of valid method names. This can be achieved by implementing a whitelist of permitted method names and validating `type` against this whitelist before invoking the method.

1. Define a whitelist of valid method names in the `JsonRenderer` class.
2. Modify the `createJsonItemHtml` method to check if `type` is in the whitelist before invoking the corresponding method.
3. Ensure that the validation logic prevents prototype pollution attacks by using `Object.prototype.hasOwnProperty.call` and checking the type of the property.

--- 

JavaScript makes it easy to look up object properties dynamically at runtime. In particular, methods can be looked up by name and then called. However, if the method name is user-controlled, an attacker could choose a name that makes the application invoke an unexpected method, which may cause a runtime exception. If this exception is not handled, it could be used to mount a denial-of-service attack.

there might not be a method of the given name, or the result of the lookup might not be a function. In either case the method call will throw a `TypeError` at runtime. Another, more subtle example is where the result of the lookup is a standard library method from `Object.prototype`, which most objects have on their prototype chain. Examples of such methods include `valueOf`, `hasOwnProperty` and `__defineSetter__`. If the method call passes the wrong number or kind of arguments to these methods, they will throw an exception.




[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
[Object.prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype).
