### PR TITLE
[DB Loader] Logging skipped schema objects

### DIFF
--- a/code/tools/trim_schema_json.py
+++ b/code/tools/trim_schema_json.py
@@ -16,11 +16,13 @@ def should_skip_item(site, item):
     if item is None:
         return True
     if "@type" in item and item["@type"] in skip_types:
+        print(f"Skipping item of type \"{item['@type']}\" for site {site}: {str(item)[:100]}...")
         return True
     # Check if @type is a list and if any value in the list is in skip_types
     elif "@type" in item and isinstance(item["@type"], list):
         for type_value in item["@type"]:
             if type_value in skip_types:
+                print(f"Skipping item of type \"{type_value}\" for site {site}: {str(item)[:100]}...")
                 return True
     elif "@type" not in item:
         print(f"Warning: Item without @type field found for site {site}, keeping item: {str(item)[:100]}...")


### PR DESCRIPTION
This PR proposes logging skipped schema items whose type is in the `skip_types` list of `trim_schema_json.py`.

I was trying to test load the O'Reilly catalogue from [`OtherDataSources.txt`](https://github.com/microsoft/NLWeb/blob/89e32b14230a2f22538cf8a405f881b3db69cf70/demo/OtherDataSources.txt), and was confused by the error message "No documents were extracted from the file." Turns out it was because all the items have type "CollectionPage" which is part of the skip list, but that wasn't apparent without debugging.