### PR TITLE
fix: nlws message type support for modern chat interface

### DIFF
--- a/static/fp-chat-interface.js
+++ b/static/fp-chat-interface.js
@@ -415,6 +415,12 @@ class ModernChatInterface {
           allResults = allResults.concat(data.results);
           console.log('Results with scores:', data.results.map(r => ({ title: r.title || r.name, score: r.score }))); // Debug log
           textDiv.innerHTML = messageContent + this.renderItems(allResults);
+        } else if (data.message_type === 'nlws' && data.items && data.items.length > 0) {
+          // Render response from chat completions API (`generate`-type answer)
+          messageContent += data.answer + '\n\n';
+          // Accumulate all search items
+          allResults = allResults.concat(data.items);
+          textDiv.innerHTML = messageContent + this.renderItems(allResults);
         } else if (data.message_type === 'intermediate_message' && data.message) {
           messageContent += data.message + '\n';
           textDiv.innerHTML = messageContent + this.renderItems(allResults);

--- a/static/fp-chat-interface.js
+++ b/static/fp-chat-interface.js
@@ -415,11 +415,13 @@ class ModernChatInterface {
           allResults = allResults.concat(data.results);
           console.log('Results with scores:', data.results.map(r => ({ title: r.title || r.name, score: r.score }))); // Debug log
           textDiv.innerHTML = messageContent + this.renderItems(allResults);
-        } else if (data.message_type === 'nlws' && data.items && data.items.length > 0) {
+        } else if (data.message_type === 'nlws' && data.items) {
           // Render response from chat completions API (`generate`-type answer)
           messageContent += data.answer + '\n\n';
           // Accumulate all search items
-          allResults = allResults.concat(data.items);
+          if (data.items.length > 0) {
+            allResults = allResults.concat(data.items);
+          }
           textDiv.innerHTML = messageContent + this.renderItems(allResults);
         } else if (data.message_type === 'intermediate_message' && data.message) {
           messageContent += data.message + '\n';

--- a/static/fp-chat-interface.js
+++ b/static/fp-chat-interface.js
@@ -415,11 +415,11 @@ class ModernChatInterface {
           allResults = allResults.concat(data.results);
           console.log('Results with scores:', data.results.map(r => ({ title: r.title || r.name, score: r.score }))); // Debug log
           textDiv.innerHTML = messageContent + this.renderItems(allResults);
-        } else if (data.message_type === 'nlws' && data.items) {
+        } else if (data.message_type === 'nlws') {
           // Render response from chat completions API (`generate`-type answer)
           messageContent += data.answer + '\n\n';
           // Accumulate all search items
-          if (data.items.length > 0) {
+          if (data.items && data.items.length > 0) {
             allResults = allResults.concat(data.items);
           }
           textDiv.innerHTML = messageContent + this.renderItems(allResults);

--- a/static/index.html
+++ b/static/index.html
@@ -426,6 +426,7 @@
     }
 
     .message-text {
+      color: var(--text-primary);
       line-height: 1.5;
       white-space: pre-wrap;
       word-wrap: break-word;


### PR DESCRIPTION
The modern chat interface seems to be missing support for `nlws` message type from the `/ask` API. If I switch `generate_mode` from `list` to `generate`, the message wouldn't be rendered:

https://github.com/microsoft/NLWeb/blob/89e32b14230a2f22538cf8a405f881b3db69cf70/static/fp-chat-interface.js#L353

This PR proposes a quick implementation to add that support:

![Screenshot 2025-07-02 184446](https://github.com/user-attachments/assets/41a7a5b2-001d-4f7d-af77-5b3f9ec58d0e)