### PR TITLE
fix: nlws message types are not displayed

### DIFF
--- a/static/fp-chat-interface.js
+++ b/static/fp-chat-interface.js
@@ -637,6 +637,22 @@ class ModernChatInterface {
             console.log('key_name:', data.key_name, 'has value?', !!data.key_value);
           }
           
+        } else if (data.message_type === 'nlws') {
+          // Handle NLWS message type (Natural Language Web Search synthesized response)
+          
+          // Update the answer if provided
+          if (data.answer && typeof data.answer === 'string') {
+            messageContent = data.answer + '\n\n';
+          }
+          
+          // Update the items if provided
+          if (data.items && Array.isArray(data.items)) {
+            allResults = data.items;
+          }
+          
+          // Always update the display with current answer and items
+          textDiv.innerHTML = messageContent + this.renderItems(allResults);
+          
         } else if (data.message_type === 'chart_result') {
           // Handle chart result (web components)
           console.log('=== Chart Result Handler Called ===');


### PR DESCRIPTION
Currently, nlws message types are not displayed in the chat interface.
Steps to reproduce:
1. In the chat interface select the mode "generate"
2. Enter any query
3. The UI remains blank

This PR adds supports for nwls message types.

### After:
<img width="884" height="728" alt="image" src="https://github.com/user-attachments/assets/742fa274-5289-44fc-ab26-2a98f26d3204" />
